### PR TITLE
DM-33930: Deploy image to GitHub Container Registry

### DIFF
--- a/.github/docker-tag.sh
+++ b/.github/docker-tag.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Determine the tag for Docker images based on GitHub Actions environment
+# variables.
+
+set -eo pipefail
+
+if [ -n "$GITHUB_HEAD_REF" ]; then
+    # For pull requests
+    echo ${GITHUB_HEAD_REF} | sed -E 's,/,-,g'
+else
+    # For push events
+    echo ${GITHUB_REF} | sed -E 's,refs/(heads|tags)/,,' | sed -E 's,/,-,g'
+fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,35 +82,26 @@ jobs:
         uses: docker/setup-buildx-action@v1
         id: builder
 
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-buildx-
-
       - name: Log in to Docker Hub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: .
           push: true
-          tags: lsstsqre/times-square-ui:${{ steps.vars.outputs.tag }}
-          target: production
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
-          build-args: |
-            GH_PKG_TOKEN=${{ secrets.GITHUB_TOKEN }}
-
-      # Temp fix
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          tags: |
+            lsstsqre/times-square-ui:${{ steps.vars.outputs.tag }}
+            ghcr.io/lsst-sqre/times-square-ui:${{ steps.vars.outputs.tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,8 +62,14 @@ jobs:
   docker:
     needs: [test]
 
-    # Only do Docker builds for pushes to ticket branches and tagged releases.
-    if: startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/tickets/')
+    # Only do Docker builds of tagged releases and pull requests from ticket
+    # branches.  This will still trigger on pull requests from untrusted
+    # repositories whose branch names match our tickets/* branch convention,
+    # but in this case the build will fail with an error since the secret
+    # won't be set.
+    if: >
+      startsWith(github.ref, 'refs/tags/') || startsWith(github.head_ref, 'tickets/')
+
 
     runs-on: ubuntu-latest
 
@@ -72,7 +78,7 @@ jobs:
 
       - name: Define the Docker tag
         id: vars
-        run: echo ::set-output name=tag::$(echo ${GITHUB_REF} | sed -E 's,refs/(heads|tags)/,,' | sed -E 's,/,-,g')
+        run: echo ::set-output name=tag::$(.github/docker-tag.sh)
 
       - name: Print the tag
         id: print

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,3 +111,5 @@ jobs:
             ghcr.io/lsst-sqre/times-square-ui:${{ steps.vars.outputs.tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            GH_PKG_TOKEN=${{ secrets.GITHUB_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@lsst-sqre:registry=https://npm.pkg.github.com/

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,10 @@ FROM node:16-alpine as builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+RUN cp --remove-destination "$(readlink ./public/operations-lineup-block.png)" ./public/operations-lineup-block.png
+RUN cp --remove-destination "$(readlink ./public/rubin-favicon-transparent-32px.png)" ./public/rubin-favicon-transparent-32px.png
+RUN cp --remove-destination "$(readlink ./public/rubin-imagotype-color-on-black.png)" ./public/rubin-imagotype-color-on-block.png
+RUN cp --remove-destination "$(readlink ./public/rubin-imagotype-color-on-black.svg)" ./public/rubin-imagotype-color-on-block.svg
 RUN npm run build
 
 # Stage 3: Install pre-built app and deps for production ======================

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 
 COPY --from=builder /app/node_modules ./node_modules
-COPY --from=builder /app/.next ./next
+COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/next.config.js ./
 COPY --from=builder /app/times-square.config.schema.json ./
 COPY --from=builder /app/public ./public
@@ -48,4 +48,4 @@ USER nextjs
 EXPOSE 3000
 ENV PORT 3000
 
-CMD ["npm", "run start"]
+CMD ["node_modules/.bin/next", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-# Stage 1: Build the application
-FROM node:16-alpine AS builder
+# Stage 1: Install dependencies ===============================================
+FROM node:16-alpine AS deps
 
 # If necessary, add libc6-compat (e.g. for process.dlopen)
-# apk add --no-cache libc6-compat
+RUN apk add --no-cache libc6-compat
 
 # GitHub Personal Access token to install from GitHub Packages
 # Needs:
@@ -11,34 +11,46 @@ ARG GH_PKG_TOKEN
 
 WORKDIR /app
 
+# .npmrc is not copied into the "producer" docker image
 RUN echo "//npm.pkg.github.com/:_authToken=${GH_PKG_TOKEN}" > ~/.npmrc
 
 COPY package.json package-lock.json .npmrc ./
-RUN npm install
+RUN npm ci
 
+# Stage 2: Build application ==================================================
+FROM node:16-alpine as builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-
 RUN npm run build
-RUN npm install --production
 
-
-# Stage 2: Install pre-built app and deps for production
+# Stage 3: Install pre-built app and deps for production ======================
 FROM node:16-alpine as production
 
 WORKDIR /app
 ENV NODE_ENV production
+# Disable next.js telemtry in run-time
+ENV NEXT_TELEMETRY_DISABLED 1
 
-# COPY --from=builder /app/public ./public
-COPY --from=builder /app/.next ./.next
-COPY --from=builder /app/node_modules ./node_modules
-# COPY --from=builder /app/next.config.js ./next.config.js
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+COPY --from=builder /app/next.config.js ./
+COPY --from=builder /app/times-square.config.schema.json ./
+COPY --from=builder /app/public ./public
 COPY --from=builder /app/package.json ./package.json
 
-RUN addgroup -g 1001 -S nodejs
-RUN adduser -S nextjs -u 1001
-RUN chown -R nextjs:nodejs /app/.next
+# Automatically leverage output traces to reduce image size
+# https://nextjs.org/docs/advanced-features/output-file-tracing
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
 USER nextjs
 
 EXPOSE 3000
+ENV PORT 3000
 
 CMD ["npm", "run start"]
+# server.js comes from .next/standalone via output file tracing
+# https://nextjs.org/docs/advanced-features/output-file-tracing
+CMD ["node", "server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,15 +17,18 @@ RUN echo "//npm.pkg.github.com/:_authToken=${GH_PKG_TOKEN}" > ~/.npmrc
 COPY package.json package-lock.json .npmrc ./
 RUN npm ci
 
+RUN ls node_modules
+
 # Stage 2: Build application ==================================================
 FROM node:16-alpine as builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-RUN cp --remove-destination "$(readlink ./public/operations-lineup-block.png)" ./public/operations-lineup-block.png
-RUN cp --remove-destination "$(readlink ./public/rubin-favicon-transparent-32px.png)" ./public/rubin-favicon-transparent-32px.png
-RUN cp --remove-destination "$(readlink ./public/rubin-imagotype-color-on-black.png)" ./public/rubin-imagotype-color-on-block.png
-RUN cp --remove-destination "$(readlink ./public/rubin-imagotype-color-on-black.svg)" ./public/rubin-imagotype-color-on-block.svg
+WORKDIR /app/public
+# RUN cp --remove-destination "$(readlink ./operations-lineup-block.png)" ./operations-lineup-block.png
+# RUN cp --remove-destination "$(readlink ./rubin-favicon-transparent-32px.png)" ./rubin-favicon-transparent-32px.png
+# RUN cp --remove-destination "$(readlink ./rubin-imagotype-color-on-black.png)" ./rubin-imagotype-color-on-block.png
+# RUN cp --remove-destination "$(readlink ./rubin-imagotype-color-on-black.svg)" ./rubin-imagotype-color-on-block.svg
 RUN npm run build
 
 # Stage 3: Install pre-built app and deps for production ======================

--- a/next.config.js
+++ b/next.config.js
@@ -44,6 +44,10 @@ module.exports = (phase, { defaultConfig }) => {
       ...publicYamlConfig,
       basePath,
     },
+    experimental: {
+      // https://nextjs.org/docs/advanced-features/output-file-tracing
+      outputStandalone: true,
+    },
     async rewrites() {
       // For both the source and destination, don't include the basePath
       // prefix for internal (same host) paths; next will apply it

--- a/next.config.js
+++ b/next.config.js
@@ -68,5 +68,6 @@ module.exports = (phase, { defaultConfig }) => {
       ];
     },
   };
+  console.log(config);
   return config;
 };

--- a/next.config.js
+++ b/next.config.js
@@ -44,10 +44,10 @@ module.exports = (phase, { defaultConfig }) => {
       ...publicYamlConfig,
       basePath,
     },
-    experimental: {
-      // https://nextjs.org/docs/advanced-features/output-file-tracing
-      outputStandalone: true,
-    },
+    // experimental: {
+    //   // https://nextjs.org/docs/advanced-features/output-file-tracing
+    //   outputStandalone: true,
+    // },
     async rewrites() {
       // For both the source and destination, don't include the basePath
       // prefix for internal (same host) paths; next will apply it

--- a/pages/api/dev/times-square/v1/pages.js
+++ b/pages/api/dev/times-square/v1/pages.js
@@ -11,7 +11,7 @@ export default function handler(req, res) {
   const { timesSquareApiUrl } = publicRuntimeConfig;
 
   const createPage = (name) => {
-    const pageBaseUrl = `${timesSquareApiUrl}pages/${name}`;
+    const pageBaseUrl = `${timesSquareApiUrl}/v1/pages/${name}`;
     return {
       name,
       self_url: pageBaseUrl,

--- a/pages/api/dev/times-square/v1/pages.js
+++ b/pages/api/dev/times-square/v1/pages.js
@@ -15,27 +15,10 @@ export default function handler(req, res) {
     return {
       name,
       self_url: pageBaseUrl,
-      source_url: `${pageBaseUrl}/source`,
-      rendered_url: `${pageBaseUrl}/rendered`,
-      html_url: `${pageBaseUrl}/html`,
-      parameters: {
-        a: {
-          type: 'number',
-          default: 42,
-          description: 'A number.',
-        },
-        b: {
-          type: 'string',
-          default: 'Hello',
-          description: 'A string.',
-        },
-      },
     };
   };
 
-  const content = {
-    data: [createPage('mypage'), createPage('anotherpage')],
-  };
+  const content = [createPage('mypage'), createPage('anotherpage')];
 
   res.statusCode = 200;
   res.setHeader('Content-Type', 'application/json');

--- a/pages/api/dev/times-square/v1/pages/[page].js
+++ b/pages/api/dev/times-square/v1/pages/[page].js
@@ -7,7 +7,7 @@ export default function handler(req, res) {
   const { page } = req.query;
   const { publicRuntimeConfig } = getConfig();
   const { timesSquareApiUrl } = publicRuntimeConfig;
-  const pageBaseUrl = `${timesSquareApiUrl}pages/${page}`;
+  const pageBaseUrl = `${timesSquareApiUrl}/v1/pages/${page}`;
 
   if (page == 'not-found') {
     // simulate a page that doesn't exist in the backend

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,15 +2,13 @@ import { useFetch } from '../hooks/fetch';
 import getConfig from 'next/config';
 import Link from 'next/link';
 
-function HomePage() {
-  const { publicRuntimeConfig } = getConfig();
+function HomePage({ publicRuntimeConfig }) {
   const { timesSquareApiUrl } = publicRuntimeConfig;
   const pagesDataUrl = `${timesSquareApiUrl}/v1/pages`;
-  const { status, error, data } = useFetch(pagesDataUrl);
+
+  const { status, error, data: pageResources } = useFetch(pagesDataUrl);
 
   if (status == 'fetched') {
-    const { data: pageResources } = data;
-
     return (
       <>
         <h1>Times Square</h1>
@@ -32,5 +30,11 @@ function HomePage() {
     return <div>Loading...</div>;
   }
 }
+
+HomePage.getInitialProps = async ({}) => {
+  // use getInitialProps to ensure the page isn't statically rendered
+  const { publicRuntimeConfig } = getConfig();
+  return { publicRuntimeConfig };
+};
 
 export default HomePage;

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,7 +5,7 @@ import Link from 'next/link';
 function HomePage() {
   const { publicRuntimeConfig } = getConfig();
   const { timesSquareApiUrl } = publicRuntimeConfig;
-  const pagesDataUrl = `${timesSquareApiUrl}pages`;
+  const pagesDataUrl = `${timesSquareApiUrl}/v1/pages`;
   const { status, error, data } = useFetch(pagesDataUrl);
 
   if (status == 'fetched') {

--- a/pages/nb/[nbSlug].js
+++ b/pages/nb/[nbSlug].js
@@ -41,7 +41,6 @@ function TSNotebookViewer({ nbSlug, userParameters }) {
 
   if (status === 'fetched') {
     const { parameters, html_url: htmlApiUrl } = data;
-    console.log(htmlApiUrl);
 
     // Merge user-set parameters with defaults
     const updatedParameters = Object.entries(parameters).map((item) => {

--- a/pages/nb/[nbSlug].js
+++ b/pages/nb/[nbSlug].js
@@ -9,6 +9,8 @@ const NotebookViewLayout = styled.div`
   display: flex;
   flex-direction: row;
   min-width: 100%;
+  // FIXME need a more reliable of making the viewer use all whitespace
+  height: calc(100vh - 200px);
 `;
 
 const NotebookSettingsContainer = styled.div`
@@ -29,6 +31,7 @@ const NotebookPageContainer = styled.div`
     border: 0px solid black;
     box-shadow: var(--shadow-elevation-medium);
     width: 100%;
+    height: 100%;
   }
 `;
 

--- a/pages/nb/[nbSlug].js
+++ b/pages/nb/[nbSlug].js
@@ -36,7 +36,7 @@ function TSNotebookViewer({ nbSlug, userParameters }) {
   // Get data about the page itself
   const { publicRuntimeConfig } = getConfig();
   const { timesSquareApiUrl } = publicRuntimeConfig;
-  const pageDataUrl = `${timesSquareApiUrl}pages/${nbSlug}`;
+  const pageDataUrl = `${timesSquareApiUrl}/v1/pages/${nbSlug}`;
   const { status, error, data } = useFetch(pageDataUrl);
 
   if (status === 'fetched') {

--- a/times-square.config.yaml
+++ b/times-square.config.yaml
@@ -3,4 +3,4 @@ baseUrl: 'http://localhost:3000'
 siteDescription: |
   The site description.
 semaphoreUrl: 'https://data-dev.lsst.cloud/semaphore'
-timesSquareApiUrl: 'http://localhost:3000/times-square/api/'
+timesSquareApiUrl: 'http://localhost:8080/times-square/api'

--- a/times-square.config.yaml
+++ b/times-square.config.yaml
@@ -3,4 +3,4 @@ baseUrl: 'http://localhost:3000'
 siteDescription: |
   The site description.
 semaphoreUrl: 'https://data-dev.lsst.cloud/semaphore'
-timesSquareApiUrl: 'http://localhost:3000/times-square/api/v1/'
+timesSquareApiUrl: 'http://localhost:3000/times-square/api/'

--- a/times-square.config.yaml
+++ b/times-square.config.yaml
@@ -3,4 +3,4 @@ baseUrl: 'http://localhost:3000'
 siteDescription: |
   The site description.
 semaphoreUrl: 'https://data-dev.lsst.cloud/semaphore'
-timesSquareApiUrl: 'http://localhost:8080/times-square/api'
+timesSquareApiUrl: 'http://localhost:3000/times-square/api'


### PR DESCRIPTION
This deploys the Docker image to GHCR in addition to Docker Hub as part of our initial migration out of Docker Hub.

Also employs the new method of caching docker layers with docker/build-push-action.

We well, this PR includes some changes to the web app itself to integrate properly with the Times Square API (fetching the page listing).